### PR TITLE
chore: update go-jose

### DIFF
--- a/cmd/create/main.go
+++ b/cmd/create/main.go
@@ -9,11 +9,12 @@ import (
 	"os"
 	"time"
 
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/json"
+	"github.com/go-jose/go-jose/v4/jwt"
+
 	localjwt "github.com/jamestelfer/chinmina-bridge/internal/jwt"
 	"github.com/sethvargo/go-envconfig"
-	"gopkg.in/go-jose/go-jose.v2"
-	"gopkg.in/go-jose/go-jose.v2/json"
-	"gopkg.in/go-jose/go-jose.v2/jwt"
 )
 
 type Config struct {
@@ -90,7 +91,7 @@ func createJWT(jwk *jose.JSONWebKey, claims ...any) (string, error) {
 		builder = builder.Claims(claim)
 	}
 
-	token, err := builder.CompactSerialize()
+	token, err := builder.Serialize()
 	if err != nil {
 		return "", err
 	}

--- a/go.mod
+++ b/go.mod
@@ -59,3 +59,6 @@ require (
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+// replaced as the OAuth middleware is depending on a version with a published vulnerability
+replace gopkg.in/go-jose/go-jose.v2 v2.6.2 => gopkg.in/go-jose/go-jose.v2 v2.6.3

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/auth0/go-jwt-middleware/v2 v2.2.1
 	github.com/bradleyfalzon/ghinstallation/v2 v2.10.0
 	github.com/buildkite/go-buildkite/v3 v3.11.0
+	github.com/go-jose/go-jose/v4 v4.0.1
 	github.com/google/go-github/v61 v61.0.0
 	github.com/justinas/alice v1.2.0
 	github.com/maypok86/otter v1.2.0
@@ -15,7 +16,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.26.0
 	go.opentelemetry.io/otel/sdk v1.26.0
 	go.opentelemetry.io/otel/sdk/metric v1.26.0
-	gopkg.in/go-jose/go-jose.v2 v2.6.2
 )
 
 require (
@@ -36,6 +36,7 @@ require (
 	github.com/stretchr/objx v0.5.2 // indirect
 	golang.org/x/net v0.23.0 // indirect
 	golang.org/x/sys v0.19.0 // indirect
+	gopkg.in/go-jose/go-jose.v2 v2.6.2 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/gammazero/deque v0.2.1 h1:qSdsbG6pgp6nL7A0+K/B7s12mcCY/5l5SIUpMOl+dC0=
 github.com/gammazero/deque v0.2.1/go.mod h1:LFroj8x4cMYCukHJDbxFCkT+r9AndaJnFMuZDV34tuU=
+github.com/go-jose/go-jose/v4 v4.0.1 h1:QVEPDE3OluqXBQZDcnNvQrInro2h0e4eqNbnZSWqS6U=
+github.com/go-jose/go-jose/v4 v4.0.1/go.mod h1:WVf9LFMHh/QVrmqrOfqun0C45tMe3RoiKJMPvgWwLfY=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=
 github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/go.sum
+++ b/go.sum
@@ -119,7 +119,7 @@ google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHh
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
-gopkg.in/go-jose/go-jose.v2 v2.6.2 h1:Rl5+9rA0kG3vsO1qhncMPRT5eHICihAMQYJkD7u/i4M=
-gopkg.in/go-jose/go-jose.v2 v2.6.2/go.mod h1:zzZDPkNNw/c9IE7Z9jr11mBZQhKQTMzoEEIoEdZlFBI=
+gopkg.in/go-jose/go-jose.v2 v2.6.3 h1:nt80fvSDlhKWQgSWyHyy5CfmlQr+asih51R8PTWNKKs=
+gopkg.in/go-jose/go-jose.v2 v2.6.3/go.mod h1:zzZDPkNNw/c9IE7Z9jr11mBZQhKQTMzoEEIoEdZlFBI=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/jwt/jwt.go
+++ b/internal/jwt/jwt.go
@@ -8,11 +8,12 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/go-jose/go-jose/v4"
+
 	jwtmiddleware "github.com/auth0/go-jwt-middleware/v2"
 	"github.com/auth0/go-jwt-middleware/v2/jwks"
 	"github.com/auth0/go-jwt-middleware/v2/validator"
 	"github.com/rs/zerolog/log"
-	"gopkg.in/go-jose/go-jose.v2"
 
 	"github.com/jamestelfer/chinmina-bridge/internal/config"
 )

--- a/internal/jwt/jwt_test.go
+++ b/internal/jwt/jwt_test.go
@@ -9,12 +9,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+
 	jwtmiddleware "github.com/auth0/go-jwt-middleware/v2"
 	"github.com/jamestelfer/chinmina-bridge/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/go-jose/go-jose.v2"
-	"gopkg.in/go-jose/go-jose.v2/jwt"
 )
 
 /*
@@ -256,7 +257,7 @@ func createRequestJWT(t *testing.T, jwk *jose.JSONWebKey, issuer string, claims 
 		Issuer: issuer,
 	})
 
-	token, err := builder.CompactSerialize()
+	token, err := builder.Serialize()
 	require.NoError(t, err)
 
 	t.Logf("issued token=%s", token)


### PR DESCRIPTION
Use latest possible version to avoid published vulnerability.

The attack surface of the vulnerability isn't used, but the upgrade is still handy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Updated JWT handling to use a newer version of the go-jose library, enhancing security and performance.
	- Changed JWT serialization method to improve reliability in token generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->