### PR TITLE
ci: release automation with GoReleaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  push:
+    # version tags are protected in this repository
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    # deploy with the correct environment to allow DockerHub access
+    environment: Publish
+
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Release
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          distribution: goreleaser
+          version: v1.25.1
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,8 @@ name: Test and coverage
 
 on:
   push:
-    branches: main
+    branches:
+      - main
   pull_request:
 
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,76 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+
+builds:
+  - id: release
+    binary: chinmina-bridge
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+
+checksum:
+  name_template: "checksums.txt"
+
+archives:
+  - format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+
+changelog:
+  use: github-native
+  sort: asc
+
+release:
+  prerelease: auto
+  header: |
+    # chinmina-bridge ({{ .Version }})
+
+    Binaries of this build can be found below, if these are needed.
+
+    The preferred way to consume a release is via its [Docker
+    image](https://hub.docker.com/r/chinmina/chinmina-bridge):
+
+    ```text
+    chinmina/chinmina-bridge:{{ .Tag }}
+    ```
+
+    The image is published for Linux for both x86-64 and ARM-64.
+
+kos:
+  -
+    id: chinmina-bridge
+    build: release
+    working_dir: .
+    base_image: cgr.dev/chainguard/static
+
+    repository: chinmina
+
+    # Platforms to build and publish.
+    #
+    # Default: 'linux/amd64'
+    platforms:
+      - linux/amd64
+      - linux/arm64
+
+    # Tag to build and push.
+    # Empty tags are ignored.
+    #
+    # Default: 'latest'
+    # Templates: allowed
+    tags:
+      - "{{if not .Prerelease}}latest{{end}}"
+      - "{{.Tag}}"
+
+    sbom: spdx
+
+    # Bare uses a tag on the $KO_DOCKER_REPO without anything additional.
+    bare: true
+
+    # Whether to preserve the full import path after the repository name.
+    preserve_import_paths: false
+
+    # Whether to use the base path without the MD5 hash after the repository name.
+    base_import_paths: true


### PR DESCRIPTION
Publishes to GitHub and DockerHub using GoReleaser.

The workflow publishes when `v*` style tags are built: release secrets use GitHub tag and deployment environment protection.

Container images are based on the [Chainguard Static container](https://images.chainguard.dev/directory/image/static/versions) and run as non-root. They are published to the `chinmina/chinmina-bridge` [repository](https://hub.docker.com/repository/docker/chinmina/chinmina-bridge/general). 

Closes #13 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Implemented a new automated release workflow to enhance software deployment efficiency.
	- Updated testing workflow to respond to changes in the main branch, ensuring more reliable builds.

- **Chores**
	- Configured automated release settings and testing parameters for the `chinmina-bridge` binary across various platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->