### PR TITLE
fix: set limits on HTTP request size

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -112,6 +112,12 @@ func handlePostGitCredentials(tokenVendor vendor.PipelineTokenVendor) http.Handl
 	})
 }
 
+func maxRequestSize(limit int64) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.MaxBytesHandler(next, limit)
+	}
+}
+
 func requestError(w http.ResponseWriter, statusCode int) {
 	http.Error(w, http.StatusText(statusCode), statusCode)
 }

--- a/main.go
+++ b/main.go
@@ -79,8 +79,9 @@ func launchServer() error {
 	}
 
 	server := &http.Server{
-		Addr:    fmt.Sprintf(":%d", cfg.Server.Port),
-		Handler: handler,
+		Addr:           fmt.Sprintf(":%d", cfg.Server.Port),
+		Handler:        handler,
+		MaxHeaderBytes: 20 << 10, // 20 KB
 	}
 
 	shutdownTelemetry, err := observe.Configure(ctx, cfg.Observe)

--- a/main.go
+++ b/main.go
@@ -32,7 +32,11 @@ func configureServerRoutes(cfg config.Config) (http.Handler, error) {
 		return nil, fmt.Errorf("authorizer configuration failed: %w", err)
 	}
 
-	authorized := alice.New(authorizer)
+	// The request body size is fairly limited to prevent accidental or
+	// deliberate abuse. Given the current API shape, this is not configurable.
+	requestLimitBytes := int64(20 << 10) // 20 KB
+
+	authorized := alice.New(maxRequestSize(requestLimitBytes), authorizer)
 
 	// setup token handler and dependencies
 	bk := buildkite.New(cfg.Buildkite)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new middleware to enforce maximum request size limits for enhanced security and stability.
	- Configured server settings to include a limit on HTTP header size.

- **Tests**
	- Added tests to ensure the new request size limit middleware functions correctly by handling oversized requests with appropriate error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->