### PR TITLE
fix: improve validation of Git credentials request

### DIFF
--- a/internal/credentialhandler/marshal.go
+++ b/internal/credentialhandler/marshal.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"net/url"
 	"strings"
 )
 
@@ -73,4 +74,29 @@ func WriteProperties(props *ArrayMap, w io.Writer) error {
 	b.WriteTo(w)
 
 	return nil
+}
+
+func ConstructRepositoryURL(props *ArrayMap) (string, error) {
+	u := &url.URL{}
+
+	protocol, ok := props.Lookup("protocol")
+	if !ok {
+		return "", errors.New("protocol/scheme must be present")
+	}
+
+	host, ok := props.Lookup("host")
+	if !ok {
+		return "", errors.New("host must be present")
+	}
+
+	path, ok := props.Lookup("path")
+	if !ok {
+		return "", errors.New("path must be present")
+	}
+
+	u.Scheme = protocol
+	u.Host = host
+	u.Path = path
+
+	return u.String(), nil
 }


### PR DESCRIPTION
Reject obviously malformed requests, and don't try to add details if they're missing.

Git credentials helpers are invoked by Git with a defined and stable protocol. Anything outside this shouldn't be handled, instead rejecting as cheaply as possible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new function for constructing repository URLs based on specific properties.
- **Refactor**
	- Improved the handling of repository URLs and error responses in Git credential management.
	- Enhanced error logging for better troubleshooting.
- **Tests**
	- Added tests to ensure the correct construction of repository URLs under various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->