### PR TITLE
fix: allow HTTP client configuration

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -18,12 +18,21 @@ source_env_if_exists .envrc.private
 # export SERVER_PORT="8080"
 # export SERVER_SHUTDOWN_TIMEOUT_SECS="25"
 
+# Change the behaviour of the HTTP client for outgoing connections. Only change
+# if server telemetry suggests it is necessary.
+# export SERVER_OUTGOING_MAX_IDLE_CONNS="100"
+# export SERVER_OUTGOING_MAX_CONNS_PER_HOST="20"
+
 #
 # Buildkite OIDC configuration
 #
 
 # required
 # export JWT_BUILDKITE_ORGANIZATION_SLUG="<your test organization slug>"
+
+# The following JWT settings are generally development only. In production, it's
+# expected that the default behaviour of retrieving the jwks.json directly from
+# Buildkite will be the preferred method.
 
 # use "make keygen" to generate a new key pair for testing
 # jwks="$(cat .development/keys/jwk-sig-testing-pub.json)"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,9 @@ type Config struct {
 type ServerConfig struct {
 	Port                   int `env:"SERVER_PORT, default=8080"`
 	ShutdownTimeoutSeconds int `env:"SERVER_SHUTDOWN_TIMEOUT_SECS, default=25"`
+
+	OutgoingHttpMaxIdleConns    int `env:"SERVER_OUTGOING_MAX_IDLE_CONNS, default=100"`
+	OutgoingHttpMaxConnsPerHost int `env:"SERVER_OUTGOING_MAX_CONNS_PER_HOST, default=20"`
 }
 
 type AuthorizationConfig struct {

--- a/main.go
+++ b/main.go
@@ -77,6 +77,8 @@ func launchServer() error {
 		return fmt.Errorf("configuration load failed: %w", err)
 	}
 
+	http.DefaultTransport = configureHttpTransport(cfg.Server)
+
 	handler, err := configureServerRoutes(cfg)
 	if err != nil {
 		return fmt.Errorf("server routing configuration failed: %w", err)
@@ -130,4 +132,13 @@ func logBuildInfo() {
 	}
 
 	ev.Msg("build information")
+}
+
+func configureHttpTransport(cfg config.ServerConfig) *http.Transport {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+
+	transport.MaxIdleConns = cfg.OutgoingHttpMaxIdleConns
+	transport.MaxConnsPerHost = cfg.OutgoingHttpMaxConnsPerHost
+
+	return transport
 }


### PR DESCRIPTION
Since most outgoing requests will be to on of 2 hosts, changes the default of idle connections per host from 2 to 20, and allows this to be configured if needed.

The maximum idle connections is also configurable, but the default is the standard Go default of 100.

Fixes #33 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced HTTP client configuration options to improve connection management.
- **Documentation**
	- Updated environment settings documentation to clarify JWT usage for different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->