### PR TITLE
fix: enable telemetry configuration

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,15 +1,25 @@
 #!/bin/sh
 
-# default values for local testing
+# By default, configure as a dev environment. This ensures logs are written in a
+# text format rather than JSON.
 export ENV=development
 
 # add your own .envrc.private file to set required configuration or override any
 # of the defaults without affecting your working copy
 source_env_if_exists .envrc.private
 
+
+
 #
-# Declare the following in your .envrc.private: don't commit these!
+# IMPORTANT
 #
+# Copy and declare the following variables in a separate file called .envrc.private:
+# don't commit your local configuration to this file!
+#
+# IMPORTANT
+#
+
+
 
 #
 # Server configuration
@@ -22,6 +32,38 @@ source_env_if_exists .envrc.private
 # if server telemetry suggests it is necessary.
 # export SERVER_OUTGOING_MAX_IDLE_CONNS="100"
 # export SERVER_OUTGOING_MAX_CONNS_PER_HOST="20"
+
+#
+# Open Telemetry configuration
+#
+
+# set to true to enable OTel tracing and metrics
+# export OBSERVE_ENABLED="false"
+
+# Allows metrics to be disabled. This is useful when metrics collection is not
+# available, as is the case when testing locally with Jaeger. Only effective
+# when OBSERVE_ENABLED is true.
+# export OBSERVE_METRICS_ENABLED="true"
+
+# may be "grpc" or "stdout"
+# export OBSERVE_TYPE="grpc"
+
+# the service name reported in traces and metrics
+# export OBSERVE_SERVICE_NAME="chinmina-bridge"
+
+# the number of seconds to wait for a batch of spans before sending to the collector
+# export OBSERVE_TRACE_BATCH_TIMEOUT_SECS="5"
+
+# the number of seconds to wait between metric read and send attempts. A shorter
+# interval may be desirable in testing, or when higher precision is required.
+# export OBSERVE_METRIC_READ_INTERVAL_SECS="60"
+
+# Standard OTel configuration is supported. See
+# https://opentelemetry.io/docs/specs/otel/protocol/exporter/ for all
+# configuration variables available.
+
+# The endpoint to which traces and metrics will be sent.
+#export OTEL_EXPORTER_OTLP_ENDPOINT==http://localhost:4317
 
 #
 # Buildkite OIDC configuration

--- a/integration/docker-compose.yaml
+++ b/integration/docker-compose.yaml
@@ -26,6 +26,10 @@ services:
       - GITHUB_APP_ID
       - GITHUB_APP_INSTALLATION_ID
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4317
+      - OBSERVE_ENABLED=true
+      # Jaeger standalone doesn't support metrics
+      - OBSERVE_METRICS_ENABLED=false
+      - OBSERVE_TYPE=grpc
     volumes:
       - "..:/src"
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,8 +42,12 @@ type GithubConfig struct {
 }
 
 type ObserveConfig struct {
-	Enabled bool   `env:"OBSERVE_ENABLED, default=false"`
-	Type    string `env:"OBSERVE_TYPE, default=grpc"`
+	Enabled                   bool   `env:"OBSERVE_ENABLED, default=false"`
+	MetricsEnabled            bool   `env:"OBSERVE_METRICS_ENABLED, default=true"`
+	Type                      string `env:"OBSERVE_TYPE, default=grpc"`
+	ServiceName               string `env:"OBSERVE_SERVICE_NAME, default=chinmina-bridge"`
+	TraceBatchTimeoutSeconds  int    `env:"OBSERVE_TRACE_BATCH_TIMEOUT_SECS, default=20"`
+	MetricReadIntervalSeconds int    `env:"OBSERVE_METRIC_READ_INTERVAL_SECS, default=60"`
 }
 
 func Load(ctx context.Context) (cfg Config, err error) {


### PR DESCRIPTION
Add configuration for supported values, including default documentation.

Some settings may have been configurable with OTel defaults, but for this small set it's useful to control directly.

## See also

OTel default environment documentation: https://opentelemetry.io/docs/specs/otel/protocol/exporter/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated instructions for configuring the development environment in `.envrc`.

- **New Features**
	- Introduced new environment variables for enhanced observability in `docker-compose.yaml`.
	- Added configuration options for telemetry and metrics in the application.

- **Refactor**
	- Updated telemetry setup to utilize new configuration parameters, improving observability features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->