### PR TITLE
fix: specify toolchain version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.DEFAULT_GOAL := build
+
 .PHONY: mod
 mod:
 	go mod download

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jamestelfer/chinmina-bridge
 
-go 1.22
+go 1.22.3
 
 require (
 	github.com/auth0/go-jwt-middleware/v2 v2.2.1


### PR DESCRIPTION
Fixes CodeQL warning, and seems a worthwhile addition.

CodeQL issue:

>As of Go 1.21, toolchain versions [must use the 1.N.P syntax](https://go.dev/doc/toolchain#version).
>
> 1.22 in go.mod does not match this syntax and there is no additional toolchain directive, which may cause some go commands to fail.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Makefile to set a default build goal.
	- Enhanced the Makefile to ensure Go modules are downloaded as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->