### PR TITLE
fix: use specific Go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jamestelfer/chinmina-bridge
 
-go 1.22
+go 1.22.3
 
 require (
 	github.com/auth0/go-jwt-middleware/v2 v2.2.1


### PR DESCRIPTION
Fixes CodeQL warning, and seems a worthwhile
addition. With this, a defined toolchain is not
required.
