### PR TITLE
fix: exclude healthcheck from telemetry

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -111,6 +111,16 @@ func handlePostGitCredentials(tokenVendor vendor.PipelineTokenVendor) http.Handl
 	})
 }
 
+func handleHealthCheck() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer drainRequestBody(r)
+
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	})
+}
+
 func maxRequestSize(limit int64) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.MaxBytesHandler(next, limit)

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -167,6 +167,7 @@ func TestHandlePostGitCredentials_ReturnsEmptySuccessWhenNoToken(t *testing.T) {
 	respBody := rr.Body.String()
 	assert.Equal(t, "", respBody)
 }
+
 func TestHandlePostGitCredentials_ReturnsFailureOnInvalidRequest(t *testing.T) {
 	tokenVendor := tv("expected-token-value")
 
@@ -246,6 +247,27 @@ func TestHandlePostGitCredentials_ReturnsFailureOnVendorFailure(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rr.Code)
 	// important to know that internal details aren't part of the error response
 	assert.Equal(t, "Internal Server Error\n", rr.Body.String())
+}
+
+func TestHandleHealthCheck_Success(t *testing.T) {
+	ctx := context.Background()
+
+	req, err := http.NewRequest("GET", "/healthcheck", nil)
+	require.NoError(t, err)
+
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	// act
+	handler := handleHealthCheck()
+	handler.ServeHTTP(rr, req)
+
+	// assert
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "text/plain", rr.Header().Get("Content-Type"))
+
+	respBody := rr.Body.String()
+	assert.Equal(t, "OK", respBody)
 }
 
 func tv(token string) vendor.PipelineTokenVendor {

--- a/main.go
+++ b/main.go
@@ -24,7 +24,8 @@ import (
 
 func configureServerRoutes(cfg config.Config) (http.Handler, error) {
 	// wrap a mux such that HTTP telemetry is configured by default
-	mux := observe.NewMux(http.NewServeMux())
+	muxWithoutTelemetry := http.NewServeMux()
+	mux := observe.NewMux(muxWithoutTelemetry)
 
 	// configure middleware
 	authorizer, err := jwt.Middleware(cfg.Authorization, jwtmiddleware.WithErrorHandler(jwt.LogErrorHandler()))
@@ -58,7 +59,9 @@ func configureServerRoutes(cfg config.Config) (http.Handler, error) {
 
 	mux.Handle("POST /token", authorized.Then(handlePostToken(tokenVendor)))
 	mux.Handle("POST /git-credentials", authorized.Then(handlePostGitCredentials(tokenVendor)))
-	mux.Handle("GET /healthcheck", handleHealthCheck())
+
+	// healthchecks are not included in telemetry
+	muxWithoutTelemetry.Handle("GET /healthcheck", handleHealthCheck())
 
 	return mux, nil
 }
@@ -138,7 +141,6 @@ func logBuildInfo() {
 	}
 	ev := log.Info()
 	for _, v := range buildInfo.Settings {
-
 		if strings.HasPrefix(v.Key, "vcs.") ||
 			strings.HasPrefix(v.Key, "GO") ||
 			v.Key == "CGO_ENABLED" {

--- a/main.go
+++ b/main.go
@@ -58,13 +58,7 @@ func configureServerRoutes(cfg config.Config) (http.Handler, error) {
 
 	mux.Handle("POST /token", authorized.Then(handlePostToken(tokenVendor)))
 	mux.Handle("POST /git-credentials", authorized.Then(handlePostGitCredentials(tokenVendor)))
-	mux.Handle("GET /healthcheck", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		defer drainRequestBody(r)
-
-		w.Header().Set("Content-Type", "text/plain")
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("OK"))
-	}))
+	mux.Handle("GET /healthcheck", handleHealthCheck())
 
 	return mux, nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a health check endpoint that responds with "OK".

- **Bug Fixes**
  - Ensured the `/healthcheck` endpoint is excluded from telemetry for more accurate monitoring.

- **Tests**
  - Added tests to verify the health check endpoint returns a successful response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->