### PR TITLE
fix: allow HTTPS credentials when SSH configured

### DIFF
--- a/internal/vendor/vendor_test.go
+++ b/internal/vendor/vendor_test.go
@@ -151,3 +151,69 @@ func TestPipelineRepositoryToken_ExpiryUnix(t *testing.T) {
 		})
 	}
 }
+
+func TestTransformSSHToHTTPS(t *testing.T) {
+	testCases := []struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{
+			name:     "ssh, valid GitHub",
+			url:      "git@github.com:organization/chinmina.git",
+			expected: "https://github.com/organization/chinmina.git",
+		},
+		{
+			name:     "ssh, no user",
+			url:      "github.com:organization/chinmina.git",
+			expected: "github.com:organization/chinmina.git",
+		},
+		{
+			name:     "ssh, different host",
+			url:      "git@githab.com:organization/chinmina.git",
+			expected: "git@githab.com:organization/chinmina.git",
+		},
+		{
+			name:     "ssh, invalid path specifier",
+			url:      "git@github.com/organization/chinmina.git",
+			expected: "git@github.com/organization/chinmina.git",
+		},
+		{
+			name:     "ssh, zero length path",
+			url:      "git@github.com:",
+			expected: "git@github.com:",
+		},
+		{
+			name:     "ssh, no extension",
+			url:      "git@github.com:organization/chinmina",
+			expected: "https://github.com/organization/chinmina",
+		},
+		{
+			name:     "https, valid",
+			url:      "https://github.com/organization/chinmina.git",
+			expected: "https://github.com/organization/chinmina.git",
+		},
+		{
+			name:     "https, nonsense",
+			url:      "https://github.com/organization/chinmina.git",
+			expected: "https://github.com/organization/chinmina.git",
+		},
+		{
+			name:     "http, valid",
+			url:      "http://github.com/organization/chinmina.git",
+			expected: "http://github.com/organization/chinmina.git",
+		},
+		{
+			name:     "pure nonsense",
+			url:      "molybdenum://mo",
+			expected: "molybdenum://mo",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := vendor.TranslateSSHToHTTPS(tc.url)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
Allow a pipeline to request HTTPS credentials of a repository that has been configured for SSH, as long as the requested repository matches the configured repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a feature to automatically convert SSH URLs to HTTPS URLs for improved compatibility and security.

- **Tests**
  - Added comprehensive tests to ensure the correct transformation of SSH URLs to HTTPS URLs across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->