### PR TITLE
fix: panic on repo URL mismatch

### DIFF
--- a/internal/vendor/cached.go
+++ b/internal/vendor/cached.go
@@ -62,7 +62,11 @@ func Cached(ttl time.Duration) (func(PipelineTokenVendor) PipelineTokenVendor, e
 				return nil, err
 			}
 
-			cache.Set(key, *token)
+			// token can be nil if the vendor wishes to indicate that there's neither
+			// a token nor an error
+			if token != nil {
+				cache.Set(key, *token)
+			}
 
 			return token, nil
 		}


### PR DESCRIPTION
Cache did not handle `nil` return from token vendor correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved caching mechanism to handle nil tokens correctly, ensuring more reliable performance.

- **Tests**
  - Added new test cases to verify caching behavior with nil responses, enhancing test coverage and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->