### PR TITLE
ci: fix errors in release process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   goreleaser:
     # deploy with the correct environment to allow DockerHub access
-    environment: "Publish"
+    environment: 'Publish'
 
     runs-on: ubuntu-latest
     steps:
@@ -39,8 +39,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: '${{ vars.DOCKERHUB_USER }}'
+          password: '${{ secrets.DOCKERHUB_TOKEN }}'
 
       - name: Release
         uses: goreleaser/goreleaser-action@v5

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,12 +23,13 @@ builds:
 # If you do this locally, sign with an OAuth identity you don't mind being permanently
 # published to a transparency log.
 binary_signs:
-  - cmd: './ci-only.sh'
+  - signature: '${artifact}.cosign.bundle'
+    cmd: './ci-only.sh'
     args:
       - "cosign"
       - "sign-blob"
       - "${artifact}"
-      - "--bundle=${artifact}.cosign.bundle"
+      - "--bundle=${signature}"
       - "--yes" # needed on cosign 2.0.0+
     output: false # the necessary output is the .cosign.bundle file
 


### PR DESCRIPTION
GoReleaser expects the `signature` file to be produced by the signing process, and adds it automatically as an artifact. If the file doesn't exist, the release fails with an odd error.

The bundle was being produced properly but separately to the `signature`, leading to the confusion.

Fixes issue introduced with binary signing in #60 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated configuration for the release workflow to enhance clarity and consistency in the Docker Hub login process.
	- Introduced a new `signature` key in the binary signing configuration for improved reference management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->