### PR TITLE
ci: remove darwin build from release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,7 +13,6 @@ builds:
     env:
       - CGO_ENABLED=0
     goos:
-      - darwin
       - linux
     goarch:
       - amd64


### PR DESCRIPTION
There is no practical reason for a macOS build of this executable. It will build an run there for local development purposes, but this doesn't mean it needs to be in a release.