### PR TITLE
ci: ensure signing bundles are uploaded alongside

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,7 +22,7 @@ builds:
 # If you do this locally, sign with an OAuth identity you don't mind being permanently
 # published to a transparency log.
 binary_signs:
-  - signature: '${artifact}.cosign.bundle'
+  - signature: '${artifact}_{{ .Os }}_{{ .Arch }}.cosign.bundle'
     cmd: './ci-only.sh'
     args:
       - "cosign"
@@ -41,7 +41,7 @@ archives:
     files:
       # cosign produces a bundle file to allow for verification of the artifacts
       # this is included in the archive to allow for easier verification after download
-      - src: '{{ .ArtifactPath }}.cosign.bundle'
+      - src: '{{ .ArtifactPath }}_{{ .Os }}_{{ .Arch }}.cosign.bundle'
         strip_parent: true
 
 changelog:


### PR DESCRIPTION
GoReleaser requires that the signature file is created by a signing process, and uploads it alongside the target binary. If the signature file is not unique then it can be overwritten by the signatures of other releases. This causes (recoverable) errors when the release is process.

If the name of the signature file is not aligned with the executable archive, it will also be difficult for the user to determine which signature file to download for a given release.

Unfortunately, this means that the bundle file now incorporated with the archive includes the OS and Arch markers, where the binary does not. This complicates the verification instructions.