### PR TITLE
ci: include signature bundles only in release archives

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,7 +22,8 @@ builds:
 # If you do this locally, sign with an OAuth identity you don't mind being permanently
 # published to a transparency log.
 binary_signs:
-  - signature: '${artifact}_{{ .Os }}_{{ .Arch }}.cosign.bundle'
+  - id: cosign
+    signature: '${artifact}.cosign.bundle'
     cmd: './ci-only.sh'
     args:
       - "cosign"
@@ -36,12 +37,13 @@ checksum:
   name_template: "checksums.txt"
 
 archives:
-  - format: tar.gz
+  - id: archives
+    format: tar.gz
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
     files:
       # cosign produces a bundle file to allow for verification of the artifacts
       # this is included in the archive to allow for easier verification after download
-      - src: '{{ .ArtifactPath }}_{{ .Os }}_{{ .Arch }}.cosign.bundle'
+      - src: '{{ .ArtifactPath }}.cosign.bundle'
         strip_parent: true
 
 changelog:
@@ -51,6 +53,9 @@ changelog:
 
 release:
   disable: "{{ .Env.RELEASE_DISABLE }}"
+
+  ids:
+    - archives
 
   prerelease: auto
   header: |


### PR DESCRIPTION
This works by naming the bundle file using the binary name with no OS or architecture information. This works around the issue with GoReleaser not working when artifact attributes
are used: https://github.com/goreleaser/goreleaser/issues/5147

The bundle is part of the release archives, so builds are verifiable, but they're not published
at the top level of the release. In some ways it's easier to have the bundle in the archive, so only one download is required.

All this said: the expected way that this will be used is via the image, not the executables, and that signature is working fine.