### PR TITLE
feat: add audit logging to the request path

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,11 @@ To understand what's right for your organization, consider:
   - it's OK if your organization controls the creation/configuration of
     pipelines: this restricts the opportunity to misconfigure a pipeline.
 
+## Operations
+
+See the [observability documentation](./docs/observability.md) for more details
+on the information provided by the system when running.
+
 ## Configuration
 
 Requirements:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,8 @@
 ignore:
   # testing utility
   - "cmd/create"
+  # has sufficient secondary coverage
+  - "internal/audit/response.go"
   # telemetry configuration
   - "internal/observe/telemetry.go"
   # bootstrap only

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,58 @@
+# Observability
+
+The system produces traces and metrics via Open Telemetry, and logs via zerolog.
+There are minimal informational logs, as well as per-request audit logs that are
+written to the process's `stdout`.
+
+## Audit logs
+
+Audit logs provide a level of non-repudiation for the system. These logs are
+written to the container's stdout, and cannot be disabled.
+
+> [!TIP]
+> Requests to non-existent routes do not form part of the audit log. Access logs
+> or firewall logs are better sources for this information.
+
+Each authenticated endpoint (both `/token` and `/git-credentials`) will record
+details about the request, the authorization process, and the GitHub token
+created. If an error occurs, this is also written out.
+
+At a technical level, logs are written to stdout using zerolog at the "audit"
+log level. Initial data is collected by request middleware and the partial entry
+is then accessible via the context. The context entry is further enriched with
+details by other components, including both the JWT middleware and the vendor.
+such that the log is fully completed by the end of the request.
+
+> [!IMPORTANT]
+> A panic in the request chain will still result in the audit log being written,
+> and the panic details will also be included.
+
+### Audit log fields
+
+1. Request data
+    - `Method`: the request method. This will currently be `GET` for all standard requests.
+    - `Path`: the requested path.
+    - `Status` is the HTTP response status of the request
+    - `SourceIP` is the client IP of the requestor
+    - `UserAgent` is the user agent reported by the client
+    - `Error` is the error produced by the request. This may come from internal
+      errors or panics, as well as the JWT validation and token creation
+      components.
+2. Authorization data
+    - `Authorized` is a boolean that is `true` when the request JWT is
+      successfully authorized by the service.
+    - `AuthSubject` is the contents of the `sub` field from the JWT
+    - `AuthIssuer` is the JWT `iss` field
+    - `AuthAudience` is the (possibly multiple) reported `aud` field values from
+      the JWT
+    - `AuthExpirySecs` is the JWT expiry time in seconds after the Unix epoch
+3. Token data
+    - `Repositories` is the set of repositories that the token allows access to
+    - `Permissions` is the set of GitHub token permissions assigned to the token
+    - `ExpirySecs` is the GitHub token expiry time in seconds after the Unix
+      epoch
+
+## Open Telemetry
+
+This section is a stub. For now, refer to the [`.envrc`](../.envrc) file for
+details of all Open Telemetry related configuration that's currently possible.

--- a/internal/audit/log.go
+++ b/internal/audit/log.go
@@ -1,0 +1,157 @@
+package audit
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/rs/zerolog"
+)
+
+// marker for interface implementation
+var _ zerolog.LogObjectMarshaler = (*Entry)(nil)
+
+// marker for context key
+type key struct{}
+
+const (
+	// Level is the log level at which audit logs are written.
+	Level = zerolog.Level(20)
+)
+
+var (
+	// logKey is the key used to store the audit log entry in the context.
+	logKey = key{}
+)
+
+// Entry is an audit log entry for the current request.
+type Entry struct {
+	Method           string
+	Path             string
+	Status           int
+	SourceIP         string
+	UserAgent        string
+	RequestedProfile string
+	Identity         string
+	Authorized       bool
+	Error            string
+	Repositories     []string
+	Permissions      []string
+}
+
+// MarshalZerologObject implements zerolog.LogObjectMarshaler. This avoids the
+// need for reflection when logging, at the cost of requiring maintenance when
+// the Entry struct changes.
+func (e *Entry) MarshalZerologObject(event *zerolog.Event) {
+	event.Str("method", e.Method).
+		Str("path", e.Path).
+		Int("status", e.Status).
+		Str("sourceIP", e.SourceIP).
+		Str("userAgent", e.UserAgent).
+		Str("requestedProfile", e.RequestedProfile).
+		Str("identity", e.Identity).
+		Bool("authorized", e.Authorized).
+		Str("error", e.Error).
+		Strs("repositories", e.Repositories).
+		Strs("permissions", e.Permissions)
+}
+
+// Begin sets up the audit log entry for the current request with details from the request.
+func (e *Entry) Begin(r *http.Request) {
+	e.Path = r.URL.Path
+	e.Method = r.Method
+	e.UserAgent = r.UserAgent()
+	e.SourceIP = r.RemoteAddr
+}
+
+// End writes the audit log entry. If the returned func is deferred, any panic
+// will be recovered so the log entry can be written before the panic is
+// re-raised.
+func (e *Entry) End(ctx context.Context) func() {
+	return func() {
+		// recover from panic if necessary
+		r := recover()
+		if r != nil {
+			// record the details of the panic, attempting to avoid overwriting an
+			// earlier error
+			e.Status = http.StatusInternalServerError
+			err := fmt.Sprintf("panic: %v", r)
+			if e.Error != "" {
+				e.Error += "; "
+			}
+			e.Error += err
+		}
+
+		// OK is the default if the status is not set when the response is written.
+		if e.Status == 0 {
+			e.Status = http.StatusOK
+		}
+
+		zerolog.Ctx(ctx).WithLevel(Level).EmbedObject(e).Str("type", "audit").Msg("audit_event")
+
+		if r != nil {
+			// repanic the panic
+			panic(r)
+		}
+	}
+}
+
+// Middleware is an HTTP middleware that creates a new audit log entry for the
+// current request and enriches it with information about the request. The log
+// entry is written to the log when the request is complete.
+//
+// A panic during the request will be recovered and logged as an error in the
+// audit entry. The HTTP status code of the response is also logged in the audit
+// entry; further details may be added by the application.
+func Middleware() func(next http.Handler) http.Handler {
+	zerologConfiguration()
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx, entry := Context(r.Context())
+
+			// wrap the response writer to capture the status code
+			response := wrapResponseWriter(w, Log(ctx))
+
+			entry.Begin(r)
+			defer entry.End(ctx)()
+
+			next.ServeHTTP(response, r.WithContext(ctx))
+		})
+	}
+}
+
+// Get the log entry for the current request. This is safe to use even if the
+// context does not create an entry.
+func Log(ctx context.Context) *Entry {
+	_, e := Context(ctx)
+	return e
+}
+
+// Context returns the Entry for the current request, creating one if it
+// does not exist. If the returned context is kept, the returned entry can be
+// further enriched. If not, information written to the entry will be lost.
+func Context(ctx context.Context) (context.Context, *Entry) {
+	e, ok := ctx.Value(logKey).(*Entry)
+	if !ok {
+		e = &Entry{}
+
+		ctx = context.WithValue(ctx, logKey, e)
+	}
+
+	return ctx, e
+}
+
+func zerologConfiguration() {
+	// configure the console writer
+	zerolog.FormattedLevels[Level] = "AUD"
+
+	// format the audit level as "audit", falling back to the default
+	marshal := zerolog.LevelFieldMarshalFunc
+	zerolog.LevelFieldMarshalFunc = func(l zerolog.Level) string {
+		if l == Level {
+			return "audit"
+		}
+		return marshal(l)
+	}
+}

--- a/internal/audit/log.go
+++ b/internal/audit/log.go
@@ -41,6 +41,7 @@ type Entry struct {
 	Error            string
 	Repositories     []string
 	Permissions      []string
+	ExpirySecs       int64
 }
 
 // MarshalZerologObject implements zerolog.LogObjectMarshaler. This avoids the
@@ -65,6 +66,14 @@ func (e *Entry) MarshalZerologObject(event *zerolog.Event) {
 		event.Time("authExpiry", exp)
 		event.Dur("authExpiryRemaining", remaining)
 	}
+
+	if e.ExpirySecs > 0 {
+		exp := time.Unix(e.ExpirySecs, 0)
+		remaining := exp.Sub(now).Round(time.Millisecond)
+		event.Time("expiry", exp)
+		event.Dur("expiryRemaining", remaining)
+	}
+
 	if len(e.AuthAudience) > 0 {
 		event.Strs("authAudience", e.AuthAudience)
 	}

--- a/internal/audit/log_test.go
+++ b/internal/audit/log_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/jamestelfer/chinmina-bridge/internal/audit"
+	"github.com/jamestelfer/chinmina-bridge/internal/testhelpers"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
@@ -15,6 +16,8 @@ import (
 func TestMiddleware(t *testing.T) {
 
 	t.Run("captures request info and configures context", func(t *testing.T) {
+		testhelpers.SetupLogger(t)
+
 		testAgent := "kettle/1.0"
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
@@ -36,6 +39,8 @@ func TestMiddleware(t *testing.T) {
 	})
 
 	t.Run("captures status code", func(t *testing.T) {
+		testhelpers.SetupLogger(t)
+
 		var capturedContext context.Context
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			capturedContext = r.Context()
@@ -55,6 +60,8 @@ func TestMiddleware(t *testing.T) {
 	})
 
 	t.Run("log written", func(t *testing.T) {
+		testhelpers.SetupLogger(t)
+
 		auditWritten := false
 
 		ctx := withLogHook(
@@ -80,6 +87,8 @@ func TestMiddleware(t *testing.T) {
 	})
 
 	t.Run("log written on panic", func(t *testing.T) {
+		testhelpers.SetupLogger(t)
+
 		auditWritten := false
 
 		ctx := withLogHook(
@@ -114,6 +123,8 @@ func TestMiddleware(t *testing.T) {
 }
 
 func TestAuditing(t *testing.T) {
+	testhelpers.SetupLogger(t)
+
 	ctx := context.Background()
 	r, _ := requestSetup()
 

--- a/internal/audit/log_test.go
+++ b/internal/audit/log_test.go
@@ -1,0 +1,142 @@
+package audit_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/jamestelfer/chinmina-bridge/internal/audit"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMiddleware(t *testing.T) {
+
+	t.Run("captures request info and configures context", func(t *testing.T) {
+		testAgent := "kettle/1.0"
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+
+			entry := audit.Log(ctx)
+			assert.Equal(t, testAgent, entry.UserAgent)
+
+			w.WriteHeader(http.StatusTeapot)
+		})
+
+		middleware := audit.Middleware()(handler)
+
+		req, w := requestSetup()
+		req.Header.Set("User-Agent", testAgent)
+
+		middleware.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusTeapot, w.Result().StatusCode)
+	})
+
+	t.Run("captures status code", func(t *testing.T) {
+		var capturedContext context.Context
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedContext = r.Context()
+			w.WriteHeader(http.StatusTeapot)
+		})
+
+		req, w := requestSetup()
+
+		middleware := audit.Middleware()(handler)
+
+		middleware.ServeHTTP(w, req)
+
+		entry := audit.Log(capturedContext)
+
+		assert.Equal(t, http.StatusTeapot, w.Result().StatusCode)
+		assert.Equal(t, http.StatusTeapot, entry.Status)
+	})
+
+	t.Run("log written", func(t *testing.T) {
+		auditWritten := false
+
+		ctx := withLogHook(
+			context.Background(),
+			zerolog.HookFunc(func(e *zerolog.Event, level zerolog.Level, msg string) {
+				if level == audit.Level {
+					auditWritten = true
+				}
+			}),
+		)
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusTeapot)
+		})
+
+		middleware := audit.Middleware()(handler)
+
+		req, w := requestSetup()
+
+		middleware.ServeHTTP(w, req.WithContext(ctx))
+
+		assert.True(t, auditWritten, "audit log entry should be written")
+	})
+
+	t.Run("log written on panic", func(t *testing.T) {
+		auditWritten := false
+
+		ctx := withLogHook(
+			context.Background(),
+			zerolog.HookFunc(func(e *zerolog.Event, level zerolog.Level, msg string) {
+				if level == audit.Level {
+					auditWritten = true
+				}
+			}),
+		)
+
+		var entry *audit.Entry
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, entry = audit.Context(r.Context())
+			entry.Error = "failure pre-panic"
+			panic("not a teapot")
+		})
+
+		middleware := audit.Middleware()(handler)
+
+		req, w := requestSetup()
+
+		assert.PanicsWithValue(t, "not a teapot", func() {
+			middleware.ServeHTTP(w, req.WithContext(ctx))
+			// this will panic as it's expected that the middleware will re-panic
+		})
+
+		assert.Equal(t, "failure pre-panic; panic: not a teapot", entry.Error)
+		assert.True(t, auditWritten, "audit log entry should be written")
+	})
+}
+
+func TestAuditing(t *testing.T) {
+	ctx := context.Background()
+	r, _ := requestSetup()
+
+	_, e := audit.Context(ctx)
+	e.Begin(r)
+	e.End(ctx)()
+
+	assert.NotEmpty(t, e.SourceIP)
+	e.SourceIP = "" // clear IP as it will change between tests
+
+	assert.Equal(t, &audit.Entry{Method: "GET", Path: "/foo", UserAgent: "kettle/1.0", Status: 200}, e)
+}
+
+func requestSetup() (*http.Request, *httptest.ResponseRecorder) {
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/foo", nil)
+	req.Header.Set("User-Agent", "kettle/1.0")
+
+	w := httptest.NewRecorder()
+
+	return req, w
+}
+
+func withLogHook(ctx context.Context, hook zerolog.HookFunc) context.Context {
+	testLog := log.Logger.With().Logger().Hook(hook)
+	return testLog.WithContext(ctx)
+}

--- a/internal/audit/response.go
+++ b/internal/audit/response.go
@@ -1,0 +1,48 @@
+package audit
+
+import (
+	"bufio"
+	"net"
+	"net/http"
+)
+
+func wrapResponseWriter(w http.ResponseWriter, e *Entry) http.ResponseWriter {
+	wrapped := &responseWrapper{responseWriter: w, entry: e}
+	if _, ok := w.(http.Hijacker); ok {
+		return &hijackWrapper{*wrapped}
+	}
+	return wrapped
+}
+
+type responseWrapper struct {
+	responseWriter http.ResponseWriter
+	entry          *Entry
+}
+
+func (w *responseWrapper) Header() http.Header {
+	return w.responseWriter.Header()
+}
+
+func (w *responseWrapper) Write(buf []byte) (int, error) {
+	return w.responseWriter.Write(buf)
+}
+
+func (w *responseWrapper) WriteHeader(code int) {
+	w.entry.Status = code
+	w.responseWriter.WriteHeader(code)
+}
+
+func (w *responseWrapper) Flush() {
+	if flusher, ok := w.responseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+// hijackWrapper wraps a response writer that supports hijacking.
+type hijackWrapper struct {
+	responseWrapper
+}
+
+func (h *hijackWrapper) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return h.responseWriter.(http.Hijacker).Hijack()
+}

--- a/internal/jwt/jwt.go
+++ b/internal/jwt/jwt.go
@@ -49,7 +49,7 @@ func Middleware(cfg config.AuthorizationConfig, options ...jwtmiddleware.Option)
 		return nil, fmt.Errorf("failed to set up the validator: %v", err)
 	}
 
-	// wrap the standard validator with additional validaton that ensures the
+	// wrap the standard validator with additional validation that ensures the
 	// core claims (including validity periods) are present
 	tokenValidator := registeredClaimsValidator(jwtValidator.ValidateToken)
 

--- a/internal/jwt/jwt.go
+++ b/internal/jwt/jwt.go
@@ -9,12 +9,13 @@ import (
 	"time"
 
 	"github.com/go-jose/go-jose/v4"
+	"github.com/justinas/alice"
 
 	jwtmiddleware "github.com/auth0/go-jwt-middleware/v2"
 	"github.com/auth0/go-jwt-middleware/v2/jwks"
 	"github.com/auth0/go-jwt-middleware/v2/validator"
-	"github.com/rs/zerolog/log"
 
+	"github.com/jamestelfer/chinmina-bridge/internal/audit"
 	"github.com/jamestelfer/chinmina-bridge/internal/config"
 )
 
@@ -49,21 +50,23 @@ func Middleware(cfg config.AuthorizationConfig, options ...jwtmiddleware.Option)
 		return nil, fmt.Errorf("failed to set up the validator: %v", err)
 	}
 
+	// Auditing of the validation process uses a combination of the error handler
+	// and the audit middleware. The first ensures that validation errors are marked in
+	// the audit log, while the second ensures that the claims are logged when the
+	// token is valid.
+
+	// force the use of the audit error handler
+	options = append(options, jwtmiddleware.WithErrorHandler(auditErrorHandler()))
+
 	// wrap the standard validator with additional validation that ensures the
 	// core claims (including validity periods) are present
 	tokenValidator := registeredClaimsValidator(jwtValidator.ValidateToken)
 
-	return jwtmiddleware.New(tokenValidator, options...).CheckJWT, nil
-}
+	validationMiddleware := jwtmiddleware.New(tokenValidator, options...).CheckJWT
 
-func LogErrorHandler() jwtmiddleware.ErrorHandler {
-	return func(w http.ResponseWriter, r *http.Request, err error) {
-		log.Warn().
-			Err(err).
-			Msg("JWT decode failure")
+	subChain := alice.New(validationMiddleware, auditClaimsMiddleware()).Then
 
-		jwtmiddleware.DefaultErrorHandler(w, r, err)
-	}
+	return subChain, nil
 }
 
 // ContextWithClaims returns a new context.Context with the provided validated claims
@@ -101,6 +104,40 @@ func RequireBuildkiteClaimsFromContext(ctx context.Context) BuildkiteClaims {
 	}
 
 	return *c
+}
+
+func auditClaimsMiddleware() func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			entry := audit.Log(r.Context())
+			claims := ClaimsFromContext(r.Context())
+
+			if claims == nil {
+				entry.Error = "JWT claims missing from context"
+			} else {
+				reg := claims.RegisteredClaims
+				entry.Authorized = true
+				entry.AuthSubject = reg.Subject
+				entry.AuthIssuer = reg.Issuer
+				entry.AuthAudience = reg.Audience
+				entry.AuthExpirySecs = reg.Expiry
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func auditErrorHandler() jwtmiddleware.ErrorHandler {
+	return func(w http.ResponseWriter, r *http.Request, err error) {
+		entry := audit.Log(r.Context())
+		entry.Error = fmt.Sprintf("JWT authorization failure: %s", err.Error())
+
+		// The default error handler will write the appropriate response status
+		// code. The status code is recorded centrally by the central audit
+		// middleware.
+		jwtmiddleware.DefaultErrorHandler(w, r, err)
+	}
 }
 
 type KeyFunc = func(ctx context.Context) (any, error)

--- a/internal/jwt/jwt_test.go
+++ b/internal/jwt/jwt_test.go
@@ -14,6 +14,7 @@ import (
 
 	jwtmiddleware "github.com/auth0/go-jwt-middleware/v2"
 	"github.com/jamestelfer/chinmina-bridge/internal/config"
+	"github.com/jamestelfer/chinmina-bridge/internal/testhelpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -118,6 +119,8 @@ func TestMiddleware(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
+			testhelpers.SetupLogger(t)
+
 			request, err := http.NewRequest(http.MethodGet, "", nil)
 			require.NoError(t, err)
 

--- a/internal/testhelpers/log.go
+++ b/internal/testhelpers/log.go
@@ -1,0 +1,27 @@
+package testhelpers
+
+import (
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+func SetupLogger(t *testing.T) {
+	t.Helper()
+
+	// capture the current global logger so it can be restored on test completion.
+	globalLogger := log.Logger
+	t.Cleanup(func() {
+		log.Logger = globalLogger
+		zerolog.DefaultContextLogger = nil
+	})
+
+	// set up a logger that writes to the test output
+	log.Logger = log.
+		Output(zerolog.NewTestWriter(t)).
+		Level(zerolog.DebugLevel)
+
+	// unless set, the context logger will not log anything
+	zerolog.DefaultContextLogger = &log.Logger
+}

--- a/internal/vendor/auditvendor.go
+++ b/internal/vendor/auditvendor.go
@@ -1,0 +1,30 @@
+package vendor
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jamestelfer/chinmina-bridge/internal/audit"
+	"github.com/jamestelfer/chinmina-bridge/internal/jwt"
+)
+
+// Auditor is a function that wraps a PipelineTokenVendor and records the result
+// of vending a token to the audit log.
+func Auditor(vendor PipelineTokenVendor) PipelineTokenVendor {
+	return func(ctx context.Context, claims jwt.BuildkiteClaims, repo string) (*PipelineRepositoryToken, error) {
+		token, err := vendor(ctx, claims, repo)
+
+		entry := audit.Log(ctx)
+		if err != nil {
+			entry.Error = fmt.Sprintf("vendor failure: %v", err)
+		} else if token == nil {
+			entry.Error = "repository mismatch, no token vended"
+		} else {
+			entry.Repositories = []string{token.RepositoryURL}
+			entry.Permissions = []string{"contents:read"}
+			entry.ExpirySecs = token.Expiry.Unix()
+		}
+
+		return token, err
+	}
+}

--- a/internal/vendor/auditvendor_test.go
+++ b/internal/vendor/auditvendor_test.go
@@ -1,0 +1,82 @@
+package vendor_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jamestelfer/chinmina-bridge/internal/audit"
+	"github.com/jamestelfer/chinmina-bridge/internal/jwt"
+	"github.com/jamestelfer/chinmina-bridge/internal/vendor"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuditor_Success(t *testing.T) {
+	successfulVendor := func(ctx context.Context, claims jwt.BuildkiteClaims, repo string) (*vendor.PipelineRepositoryToken, error) {
+		return &vendor.PipelineRepositoryToken{
+			RepositoryURL: "https://example.com/repo",
+			Expiry:        time.Now().Add(1 * time.Hour),
+		}, nil
+	}
+	auditedVendor := vendor.Auditor(successfulVendor)
+
+	ctx, _ := audit.Context(context.Background())
+	claims := jwt.BuildkiteClaims{}
+	repo := "example-repo"
+
+	token, err := auditedVendor(ctx, claims, repo)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, token)
+	assert.Equal(t, "https://example.com/repo", token.RepositoryURL)
+
+	entry := audit.Log(ctx)
+	assert.Empty(t, entry.Error)
+	assert.Equal(t, []string{"https://example.com/repo"}, entry.Repositories)
+	assert.Equal(t, []string{"contents:read"}, entry.Permissions)
+	assert.NotZero(t, entry.ExpirySecs)
+}
+
+func TestAuditor_Mismatch(t *testing.T) {
+	successfulVendor := func(ctx context.Context, claims jwt.BuildkiteClaims, repo string) (*vendor.PipelineRepositoryToken, error) {
+		return nil, nil
+	}
+	auditedVendor := vendor.Auditor(successfulVendor)
+
+	ctx, _ := audit.Context(context.Background())
+	claims := jwt.BuildkiteClaims{}
+	repo := "example-repo"
+
+	token, err := auditedVendor(ctx, claims, repo)
+
+	assert.NoError(t, err)
+	assert.Nil(t, token)
+
+	entry := audit.Log(ctx)
+	assert.Equal(t, "repository mismatch, no token vended", entry.Error)
+	assert.Empty(t, entry.Repositories)
+	assert.Empty(t, entry.Permissions)
+	assert.Zero(t, entry.ExpirySecs)
+}
+
+func TestAuditor_Failure(t *testing.T) {
+	failingVendor := func(ctx context.Context, claims jwt.BuildkiteClaims, repo string) (*vendor.PipelineRepositoryToken, error) {
+		return nil, errors.New("vendor error")
+	}
+	auditedVendor := vendor.Auditor(failingVendor)
+
+	ctx, _ := audit.Context(context.Background())
+	claims := jwt.BuildkiteClaims{}
+	repo := "example-repo"
+
+	token, err := auditedVendor(ctx, claims, repo)
+	assert.Error(t, err)
+	assert.Nil(t, token)
+
+	entry := audit.Log(ctx)
+	assert.Equal(t, "vendor failure: vendor error", entry.Error)
+	assert.Empty(t, entry.Repositories)
+	assert.Empty(t, entry.Permissions)
+	assert.Zero(t, entry.ExpirySecs)
+}

--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ func configureServerRoutes(ctx context.Context, cfg config.Config) (http.Handler
 		return nil, fmt.Errorf("vendor cache configuration failed: %w", err)
 	}
 
-	tokenVendor := vendorCache(vendor.New(bk.RepositoryLookup, gh.CreateAccessToken))
+	tokenVendor := vendor.Auditor(vendorCache(vendor.New(bk.RepositoryLookup, gh.CreateAccessToken)))
 
 	mux.Handle("POST /token", authorizedRouteMiddleware.Then(handlePostToken(tokenVendor)))
 	mux.Handle("POST /git-credentials", authorizedRouteMiddleware.Then(handlePostGitCredentials(tokenVendor)))

--- a/main.go
+++ b/main.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	jwtmiddleware "github.com/auth0/go-jwt-middleware/v2"
 	"github.com/jamestelfer/chinmina-bridge/internal/audit"
 	"github.com/jamestelfer/chinmina-bridge/internal/buildkite"
 	"github.com/jamestelfer/chinmina-bridge/internal/config"
@@ -31,7 +30,7 @@ func configureServerRoutes(ctx context.Context, cfg config.Config) (http.Handler
 	// configure middleware
 	auditor := audit.Middleware()
 
-	authorizer, err := jwt.Middleware(cfg.Authorization, jwtmiddleware.WithErrorHandler(jwt.LogErrorHandler()))
+	authorizer, err := jwt.Middleware(cfg.Authorization)
 	if err != nil {
 		return nil, fmt.Errorf("authorizer configuration failed: %w", err)
 	}


### PR DESCRIPTION
Audit logs provide a level of non-repudiation for the system. Audit logs are written to the container's stdout, and cannot be disabled.

Each authenticated endpoint (both `token` and `git-credentials`) will record details about the request, the authorisation process, and the GitHub token created. If an error occurs, this is also written out.

At a technical level, logs are written by zerolog to stdout, using the "audit" log level. Audit logs are added in place by request middleware and made available via the context. The context entry is enriched with detail by other components: both JWT middleware and the vendor itself add relevant information such that the log is fully completed by the end of the request.

Further information can be added to the log using the `audit.Log(context.Context)` API if and when this is required.

Fixes #12


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Expanded documentation with new sections on operations, configuration, and observability, including detailed setup instructions for Buildkite and GitHub integrations.
	- Introduced a comprehensive overview of audit logging for HTTP requests, detailing captured information such as method, path, status, and user agent.

- **Bug Fixes**
	- Updated middleware configuration to ensure proper logging and authorization handling.

- **Tests**
	- Developed extensive unit tests for auditing middleware and token vending functions to ensure reliability and correctness.

- **Documentation**
	- Updated README with a new "Operations" section and expanded "Configuration" section detailing integration requirements.
	- Added a new section on observability, covering logging, tracing, and audit logs, including specifics on audit log fields and Open Telemetry configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->