### PR TITLE
fix: OTEL schema incompatibility after upgrade

### DIFF
--- a/internal/observe/telemetry.go
+++ b/internal/observe/telemetry.go
@@ -23,7 +23,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
 
 // Configure sets up OpenTelemetry according to the configuration. If it does
@@ -134,13 +134,7 @@ func newTraceProvider(ctx context.Context, cfg config.ObserveConfig, e exporters
 		return nil, err
 	}
 
-	r, err := resource.Merge(
-		resource.Default(),
-		resource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceName(cfg.ServiceName),
-		),
-	)
+	r, err := resourceWithServiceName(resource.Default(), cfg.ServiceName)
 	if err != nil {
 		return nil, err
 	}
@@ -152,6 +146,16 @@ func newTraceProvider(ctx context.Context, cfg config.ObserveConfig, e exporters
 		trace.WithResource(r),
 	)
 	return traceProvider, nil
+}
+
+func resourceWithServiceName(base *resource.Resource, serviceName string) (*resource.Resource, error) {
+	return resource.Merge(
+		base,
+		resource.NewWithAttributes(
+			semconv.SchemaURL,
+			semconv.ServiceName(serviceName),
+		),
+	)
 }
 
 func newMeterProvider(ctx context.Context, cfg config.ObserveConfig, e exporters) (*metric.MeterProvider, error) {

--- a/internal/observe/telemetry_test.go
+++ b/internal/observe/telemetry_test.go
@@ -1,0 +1,18 @@
+package observe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/sdk/resource"
+)
+
+func Test_ResourceMerge(t *testing.T) {
+	// Ensure that schema incompatibility on OTEL upgrades is detected before
+	// merge
+	_, err := resourceWithServiceName(
+		resource.Default(),
+		"serviceName")
+
+	require.NoError(t, err)
+}


### PR DESCRIPTION
After the recent upgrade, the server failed to start because the OTel schema version had changed.

This is undesirable behaviour: added a unit test to catch this easily before commit.