### PR TITLE
fix: shave some size off the executable

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,6 +10,8 @@ env:
 builds:
   - id: release
     binary: chinmina-bridge
+    flags: "-trimpath" # don't include the full path of the source files
+    ldflags: "-w" # don't include DWARF symbols
     env:
       - CGO_ENABLED=0
     goos:

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,9 @@ build: dist mod
 	# build for container use: in future we will need to either use "ko" or
 	# "goreleaser" (or both) to create executables and images in the required
 	# architectures.
-	CGO_ENABLED=0 GOOS=linux go build -o dist/chinmina-bridge .
+	CGO_ENABLED=0 GOOS=linux go build -ldflags="-w" -trimpath -o dist/chinmina-bridge .
 	# build for local use, whatever the local platform is
-	CGO_ENABLED=0 go build -o dist/chinmina-bridge-local .
+	CGO_ENABLED=0 go build -ldflags="-w" -trimpath -o dist/chinmina-bridge-local .
 	CGO_ENABLED=0 go build -o dist/oidc-local cmd/create/main.go
 
 .PHONY: run


### PR DESCRIPTION
Trim symbol paths and remove DWARF debugging symbols from the built binaries. These slow compilation and increase binary size.

If debugging information is necessary, a different build target could be used.

The binary size metric is not driving this change, but more of a nice-to-have. Trimming module paths removes irrelevant information from any traces that are emitted, and speeding the build time helps development cycle time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced build process with new flags for optimized builds.
	- Introduced a distribution directory for better organization of output binaries.
- **Bug Fixes**
	- Improved handling of Go modules and test coverage reporting.
- **Documentation**
	- Updated instructions for release verification and Docker image tagging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->